### PR TITLE
WIP: 添加 dto, 通过 spring context 输出 dto 图

### DIFF
--- a/dot/spring-dot-const.go
+++ b/dot/spring-dot-const.go
@@ -1,0 +1,67 @@
+package dot
+
+import "reflect"
+
+//颜色预留，可能用作后续区分业务模块
+const (
+	GroupBgColorRed    = GroupBgColor("red")
+	GroupBgColorGreen  = GroupBgColor("green")
+	GroupBgColorBlue   = GroupBgColor("blue")
+	GroupBgColorPink   = GroupBgColor("pink")
+	GroupBgColorYellow = GroupBgColor("yellow")
+	GroupBgColorBlack  = GroupBgColor("black")
+	GroupBgColorPurple = GroupBgColor("purple")
+	GroupBgColorOrange = GroupBgColor("orange")
+	GroupBgColorCoral  = GroupBgColor("coral")
+	GroupBgColorBeige  = GroupBgColor("beige")
+	GroupBgColorBrown  = GroupBgColor("brown")
+	GroupBgColorWhite  = GroupBgColor("white")
+)
+
+//使用 NodeShapeEgg (egg) 表示 interface
+//使用 NodeShapeRecord (record) 表示 struct
+//使用 NodeShapeCircle (circle) 表示 collection : map, array, slice
+//使用 NodeShapePlaintext (plaintext) 表示基本类型
+//其余使用默认值
+//其余形状保留
+const (
+	//NodeShapeMrecord 圆角矩形
+	NodeShapeMrecord = Shape("Mrecord")
+	//NodeShapeRecord 矩形
+	NodeShapeRecord = Shape("record")
+	//NodeShapeCircle 圆形
+	NodeShapeCircle = Shape("circle")
+	//NodeShapeEgg 蛋形
+	NodeShapeEgg = Shape("egg")
+	//NodeShapePlaintext 无形状边框，纯文本
+	NodeShapePlaintext = Shape("plaintext")
+	//NodeShapeEllipse 椭圆, 默认椭圆
+	NodeShapeEllipse = Shape("Ellipse")
+)
+
+var typeShapeMapping = map[reflect.Kind]Shape{
+	reflect.Array: NodeShapeCircle,
+	reflect.Map: NodeShapeCircle,
+	reflect.Slice: NodeShapeCircle,
+
+	reflect.Struct: NodeShapeRecord,
+
+	reflect.Bool: NodeShapePlaintext,
+	reflect.Int: NodeShapePlaintext,
+	reflect.Int8: NodeShapePlaintext,
+	reflect.Int16: NodeShapePlaintext,
+	reflect.Int32: NodeShapePlaintext,
+	reflect.Int64: NodeShapePlaintext,
+	reflect.Uint: NodeShapePlaintext,
+	reflect.Uint8: NodeShapePlaintext,
+	reflect.Uint16: NodeShapePlaintext,
+	reflect.Uint32: NodeShapePlaintext,
+	reflect.Uint64: NodeShapePlaintext,
+	reflect.Uintptr: NodeShapePlaintext,
+	reflect.Float32: NodeShapePlaintext,
+	reflect.Float64: NodeShapePlaintext,
+	reflect.Complex64: NodeShapePlaintext,
+	reflect.Complex128: NodeShapePlaintext,
+
+	reflect.Interface: NodeShapeEgg,
+}

--- a/dot/spring-dot.go
+++ b/dot/spring-dot.go
@@ -1,0 +1,148 @@
+package dot
+
+import (
+	"bytes"
+	"fmt"
+	SpringCore "github.com/go-spring/spring-core"
+	"io"
+	"math"
+	"reflect"
+)
+
+//type declare here
+type GroupBgColor string
+
+type DiGraph struct {
+	//name 图名, 生成图时使用此字段声明
+	name string
+	//bgColor 背景色，可使用 #rrggbb 形式
+	bgColor GroupBgColor
+	//subGraphs 子图集合，目前无用，计划用于模块划分
+	subGraphs []DiGraph
+	//nodes 此图包含的全部节点
+	nodes []Node
+	//edges 此节点的边集合
+	edges []Edge
+}
+
+type Shape string
+
+type Node struct {
+	//name 节点名，声明时使用，取 bean的name
+	name string
+	//shape 节点形状, 现在用于区分各种数据类型, 参考 typeShapeMapping 声明
+	shape Shape
+}
+
+type Edge struct {
+	//fromName 从此节点出发
+	fromName string
+	//toName 节点指向 node
+	toName string
+}
+
+//WithContext 根据 ctx 生成图形结构
+func WithContext(ctx SpringCore.SpringContext) *DiGraph {
+	beans := ctx.GetBeanDefinitions()
+	nodes := make([]Node, len(beans))
+	edges := make([]Edge, 0, len(beans))
+
+	typeNameMap := make(map[reflect.Type]string)
+	//构建节点并记录 type - name
+	for i := range beans {
+		beanType := reflect.TypeOf(beans[i].Bean())
+		typeNameMap[beanType] = beans[i].Name()
+		nodes[i] = Node{
+			shape: getShape(beanType.Kind()),
+			name:  beans[i].Name(),
+		}
+	}
+	// 构建边
+	for i:= range beans {
+		beanType := reflect.TypeOf(beans[i].Bean())
+		if beanType.Kind() == reflect.Struct ||
+			beanType.Kind() == reflect.Ptr && beanType.Elem().Kind() == reflect.Struct {
+			aType := beanType
+			if aType.Kind() == reflect.Ptr {
+				aType = aType.Elem()
+			}
+			for j := 0; j < aType.NumField(); j++ {
+				val, ok := aType.Field(j).Tag.Lookup("autowire")
+				if ok {
+					if val != "" {
+						edges = append(edges, Edge{
+							fromName: beans[i].Name(),
+							toName:   val,
+						})
+					} else {
+						edges = append(edges, Edge{
+							fromName: beans[i].Name(),
+							toName:   typeNameMap[aType.Field(j).Type],
+						})
+					}
+				}
+			}
+		}
+	}
+	return &DiGraph{
+		name:    "springGraph",
+		bgColor: GroupBgColorWhite,
+		nodes:   nodes,
+		edges:   edges,
+	}
+}
+
+//util func here
+func RGBToBgColor(red, green, blue int) GroupBgColor {
+	return rgbToBgColor(
+		limitColorValue(red),
+		limitColorValue(green),
+		limitColorValue(blue),
+	)
+}
+
+func limitColorValue(val int) uint8 {
+	if val < 0 {
+		return 0
+	}
+	if val > math.MaxUint8 {
+		return math.MaxUint8
+	}
+	return uint8(val)
+}
+
+func rgbToBgColor(red, green, blue uint8) GroupBgColor {
+	return GroupBgColor(fmt.Sprintf("#%x%x%x", red, green, blue))
+}
+
+func getShape(kind reflect.Kind) Shape {
+	if shape, have := typeShapeMapping[kind]; have {
+		return shape
+	}
+	return NodeShapeEllipse
+}
+
+func (graph *DiGraph) ToDot(writer io.Writer) error {
+	buffer := &bytes.Buffer{}
+	buffer.Write([]byte(fmt.Sprintf("digraph %s {\n", graph.name)))
+	buffer.Write([]byte(fmt.Sprintf("  graph [bgcolor = %s]\n", graph.bgColor)))
+	for _, node := range graph.nodes {
+		buffer.Write([]byte("  "))
+		node.ToDot(buffer)
+	}
+	for _, edge := range graph.edges {
+		buffer.Write([]byte("  "))
+		edge.ToDot(buffer)
+	}
+	buffer.Write([]byte("}\n"))
+	_, err := writer.Write(buffer.Bytes())
+	return err
+}
+
+func (node *Node) ToDot(buffer *bytes.Buffer) {
+	buffer.Write([]byte(fmt.Sprintf("\"%s\"[shape = %s]\n", node.name, node.shape)))
+}
+
+func (edge *Edge) ToDot(buffer *bytes.Buffer) {
+	buffer.Write([]byte(fmt.Sprintf("\"%s\" -> \"%s\" \n", edge.fromName, edge.toName)))
+}

--- a/dot/spring-dot_test.go
+++ b/dot/spring-dot_test.go
@@ -1,0 +1,192 @@
+package dot
+
+import (
+	"bytes"
+	"fmt"
+	SpringCore "github.com/go-spring/spring-core"
+	"testing"
+)
+
+func TestDotBase(t *testing.T) {
+	shapes := []Shape{NodeShapeEgg, NodeShapeEllipse, NodeShapeCircle, NodeShapeRecord, NodeShapeMrecord}
+	nodes := make([]Node, 5)
+	for i := 0; i < 5; i++ {
+		nodes[i] = Node{
+			name:  fmt.Sprintf("node%d", i),
+			shape: shapes[i],
+		}
+	}
+	edge0 := Edge{
+		fromName:  nodes[0].name,
+		toName:    nodes[1].name,
+	}
+	edge1 := Edge{
+		fromName:  nodes[0].name,
+		toName:    nodes[2].name,
+	}
+	edge2 := Edge{
+		fromName:  nodes[1].name,
+		toName:    nodes[3].name,
+	}
+	edge3 := Edge{
+		fromName:  nodes[1].name,
+		toName:    nodes[4].name,
+	}
+
+	root := DiGraph{
+		name:    "test",
+		bgColor: GroupBgColorWhite,
+		nodes:   nodes,
+		edges: []Edge{
+			edge0,
+			edge1,
+			edge2,
+			edge3,
+		},
+	}
+	buffer := &bytes.Buffer{}
+	err := root.ToDot(buffer)
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(buffer.String())
+	}
+}
+
+func TestDotWithContext(t *testing.T) {
+	applicationContext := SpringCore.DefaultApplicationContext()
+	applicationContext.RegisterBean(&IamTestHandler{})
+	applicationContext.RegisterBean(&IamTestSimpleController{})
+	applicationContext.RegisterBean(&IamTestComplexController{})
+
+	var validators = []IamTestValidator{
+		&IamTest0Validator{},
+		&IamTest1Validator{},
+		&IamTest2Validator{},
+		&IamTest3Validator{},
+		&IamTest4Validator{},
+		&IamTest5Validator{},
+	}
+
+	applicationContext.RegisterNameBeanFn("iamTestValidator", func() IamTestValidator {
+		return validators[0]
+	})
+
+	applicationContext.RegisterBean(validators)
+
+	var services = []IamTestService{
+		&IamTestServiceRemixImpl{},
+		&IamTestServiceDBImpl{},
+		&IamTestServiceRedisImpl{},
+	}
+	applicationContext.RegisterNameBeanFn("iamTestService", func() IamTestService {
+		return services[0]
+	})
+
+	applicationContext.RegisterBean(services)
+
+	applicationContext.RegisterBean(&Redis{})
+	applicationContext.RegisterBean(&Datasource{})
+	applicationContext.AutoWireBeans()
+
+	buffer := bytes.Buffer{}
+	_ = WithContext(applicationContext).ToDot(&buffer)
+	fmt.Println(buffer.String())
+}
+
+
+// 测试用结构体
+type (
+	IamTestHandler struct {
+		IamTestSimpleController  *IamTestSimpleController  `autowire:""`
+		IamTestComplexController *IamTestComplexController `autowire:""`
+	}
+	IamTestValidator interface {
+		Validate() error
+	}
+	IamTestService interface {
+		Test() bool
+	}
+)
+
+type (
+	IamTest0Validator struct {
+	}
+	IamTest1Validator struct {
+	}
+	IamTest2Validator struct {
+	}
+	IamTest3Validator struct {
+	}
+	IamTest4Validator struct {
+	}
+	IamTest5Validator struct {
+	}
+)
+
+type (
+	IamTestSimpleController struct {
+		Validator IamTestValidator `autowire:"iamTestValidator"`
+		Service   IamTestService   `autowire:"iamTestService"`
+	}
+	IamTestComplexController struct {
+		Validators []IamTestValidator `autowire:""`
+		Services   []IamTestService   `autowire:""`
+	}
+	IamTestServiceDBImpl struct {
+		Datasource *Datasource `autowire:""`
+	}
+	Datasource struct {
+		Host     string
+		Port     uint16
+		Protocol string
+	}
+	IamTestServiceRedisImpl struct {
+		Redis *Redis `autowire:""`
+	}
+	Redis struct {
+		Host string
+		Port uint16
+	}
+	IamTestServiceRemixImpl struct {
+		Datasource *Datasource `autowire:""`
+		Redis      *Redis      `autowire:""`
+	}
+)
+
+
+func (validator *IamTest0Validator) Validate() error {
+	return nil
+}
+
+func (validator *IamTest1Validator) Validate() error {
+	return nil
+}
+
+func (validator *IamTest2Validator) Validate() error {
+	return nil
+}
+
+func (validator *IamTest3Validator) Validate() error {
+	return nil
+}
+
+func (validator *IamTest4Validator) Validate() error {
+	return nil
+}
+
+func (validator *IamTest5Validator) Validate() error {
+	return nil
+}
+
+func (service *IamTestServiceDBImpl) Test() bool {
+	return true
+}
+
+func (service *IamTestServiceRedisImpl) Test() bool {
+	return true
+}
+
+func (service *IamTestServiceRemixImpl) Test() bool {
+	return true
+}


### PR DESCRIPTION
添加一个 dto 图输出依赖关系的 base 模块，目前可以输出简单的 dto 图 ，见[TestDotWithContext](https://github.com/go-spring/spring-core/pull/1/files#diff-8316f4c35df8d192d115413242e9bd4590b013ec2704651e6fe7ec612163e07aR56)

目前做得比较粗糙，后面打算完善对 wireBean 的支持以及 struct 属性在图中的展示。

下面是输出的测试样例
```dto
digraph springGraph {
  graph [bgcolor = white]
  "*base.IamTestSimpleController"[shape = Ellipse]
  "iamTestValidator"[shape = Ellipse]
  "[]base.IamTestService"[shape = circle]
  "*base.IamTestHandler"[shape = Ellipse]
  "[]base.IamTestValidator"[shape = circle]
  "iamTestService"[shape = Ellipse]
  "*base.Redis"[shape = Ellipse]
  "*base.Datasource"[shape = Ellipse]
  "*base.IamTestComplexController"[shape = Ellipse]
  "*base.IamTestSimpleController" -> "iamTestValidator" 
  "*base.IamTestSimpleController" -> "iamTestService" 
  "*base.IamTestHandler" -> "*base.IamTestSimpleController" 
  "*base.IamTestHandler" -> "*base.IamTestComplexController" 
  "iamTestService" -> "*base.Datasource" 
  "iamTestService" -> "*base.Redis" 
  "*base.IamTestComplexController" -> "[]base.IamTestValidator" 
  "*base.IamTestComplexController" -> "[]base.IamTestService" 
}
```

在 vscode 安装插件 [graphviz](https://marketplace.visualstudio.com/items?itemName=joaompinto.vscode-graphviz)
可以通过 vs code 生成 dto svg, 能比较直观的展示各模块依赖关系
对我来说查看项目还是挺方便的，也许欢哥会感兴趣?

![b539bc73373dfa0fe3a256106d35cb06](https://user-images.githubusercontent.com/16758105/148171828-2294f0e9-9105-4158-8a8c-9e7fe2efcdb6.gif)
